### PR TITLE
changed link slides-link to /lesson-plan/

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Participants will get the most from this lesson if they have familiarity with:
 
 ## Slides
 
-*   [Slides](https://wptrainingteam.github.io/lesson-plans/theme-customizer-user/slides/) (files included in this repo)
+*   [Slides](https://wptrainingteam.github.io/lesson-plan/theme-customizer-user/slides/) (files included in this repo)
 
 ## Materials Needed
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Correcting the link to the Slides. from .../lesson-plans/... to ..../lesson-plan/... The link will not work right now, because the slides are currently unter /dev/ folder 

## Motivation and Context
Adressing the issues unter #7 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your contribution introduce? Put an `x` in all the boxes that apply: -->

- [ ] Corrects spelling, formatting, and other style issues
- [ ] Updates the content of the lesson plan
- [ ] Adds content to the lesson plan (initial draft)
- [x] Brings the lesson plan into conformance with the repo-template (including folders, files, and/or lesson plan format).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My contribution follows the style of this project. (See https://make.wordpress.org/training/handbook/guidelines/lesson-plan-style-guide/).
- [ ] If providing slides, my contribution follows the slide style for this project. (See https://make.wordpress.org/training/handbook/guidelines/slides-style-guide/).
- [ ] The lesson plan follows the current template (See https://github.com/wptrainingteam/repo-template).
- [ ] I have completed the **Team Onboarding (https://make.wordpress.org/training/handbook/getting-started/team-on-boarding/)** tasks.
